### PR TITLE
Improve Search Resource Pagination

### DIFF
--- a/lib/zendesk_api/search_resource.rb
+++ b/lib/zendesk_api/search_resource.rb
@@ -12,7 +12,7 @@ class ZendeskApi::SearchResource < ZendeskApi::Resource
     def result_ids
       results.map { |h| h["id"] }
     end
-    
+
     def tickets
       return @tickets if defined?(@tickets)
 
@@ -34,9 +34,10 @@ class ZendeskApi::SearchResource < ZendeskApi::Resource
     private
     def navigate(url)
       uri = URI.parse(url)
+
       self.class.new(
-        resource,
-        resource.build_request(:get, uri.path + "?" + uri.query))
+        @resource,
+        @resource.build_request(:get, uri.path + "?" + uri.query))
     end
   end
 

--- a/lib/zendesk_api/search_resource.rb
+++ b/lib/zendesk_api/search_resource.rb
@@ -1,4 +1,6 @@
 class ZendeskApi::SearchResource < ZendeskApi::Resource
+  PaginationError = Class.new(ZendeskApi::Error)
+
   class SearchResults
     def initialize(resource, hash)
       @resource = resource
@@ -20,11 +22,23 @@ class ZendeskApi::SearchResource < ZendeskApi::Resource
     end
 
     def next_page
+      raise PaginationError, "next page not found" unless next_page?
+
       navigate(@hash["next_page"])
     end
 
     def previous_page
+      raise PaginationError, "previous page not found" unless previous_page?
+
       navigate(@hash["previous_page"])
+    end
+
+    def next_page?
+      @hash["next_page"].present?
+    end
+
+    def previous_page?
+      @hash["previous_page"].present?
     end
 
     def count

--- a/lib/zendesk_api/tickets_resource.rb
+++ b/lib/zendesk_api/tickets_resource.rb
@@ -4,6 +4,8 @@ class ZendeskApi::TicketsResource < ZendeskApi::Resource
   end
 
   def show_many(ids)
+    return [] if ids.empty?
+
     request(:get, "show_many", ids: ids.join(","))[collection_root_element]
   end
 end


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/171883687

This PR introduces the following improvements to the gem:

- Fixes the pagination functions for `ZendeskApi::SearchResource` (fixes undefined errors)
- Provides `previous_page?` and `next_page?` helper methods for checking pagination limits without making additional requests
- Raises `ZendeskApi::SearchResource::PaginationError` exception when exceeding pagination bounds
- Fixes edge case on `#show_many` when provided empty IDs