### PR TITLE
Handle updated Zendesk endpoints

### DIFF
--- a/lib/zendesk_api/version.rb
+++ b/lib/zendesk_api/version.rb
@@ -1,3 +1,3 @@
 module ZendeskApi
-  VERSION = "0.0.12"
+  VERSION = "0.0.13"
 end


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/171883687

Zendesk recently released some breaking API results changes [1],
where the next_page param no longer returns `null` if there is
no next page available for us to query. This seems to be the case
in production but not in our sandbox environment, so we're handling
both cases via the `next_page?` method. Zendesk support appears
aware of the issue [2] and should address it at some point.

We're also updating the search API endpoint being hit by this gem,
as it has changed from `search/incremented` to `search` [3] - this
was tested on both prod and sandbox environments to work as before,
with the additional benefit of it respecting the `per_page` param
(defaults to 100 if none is passed in).

[1] https://develop.zendesk.com/hc/en-us/articles/360022563994--BREAKING-New-Search-API-Result-Limits
[2] https://develop.zendesk.com/hc/en-us/articles/360001068607/comments/360004307754
[3] https://developer.zendesk.com/rest_api/docs/support/search#list-search-results